### PR TITLE
[codex] Shrink mobile code block text

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -157,6 +157,9 @@ hr {
 	h4 {
 		font-size: 1em;
 	}
+	pre {
+		font-size: 0.9em;
+	}
 	.heading-anchor {
 		display: none;
 	}


### PR DESCRIPTION
## Summary
- reduce fenced code block text size on mobile screens
- leave inline code styling unchanged

## Root cause
Code blocks were inheriting the full body text size on mobile, and the monospace face made them read noticeably larger than the surrounding prose.

## Validation
- npm run build

Note: the build completed successfully, with sandbox DNS warnings while Astro tried to fetch Google Fonts metadata.